### PR TITLE
fix(css): Block quotes and code blocks are scrollable

### DIFF
--- a/assets/silas.css
+++ b/assets/silas.css
@@ -129,12 +129,14 @@ code {
 pre code {
     display: block;
     padding: 1em;
+    overflow-x: scroll;
 }
 
 blockquote {
     background-color: var(--lightgray);
     font-size: 90%;
     width: 80%;
+    overflow-x: scroll;
 }
 
 sup {


### PR DESCRIPTION
Noticed this on my phone, I was unable to scroll through a code snippet correctly
