### PR TITLE
fix(css): code within blockquotes is a lighter gray

### DIFF
--- a/assets/silas.css
+++ b/assets/silas.css
@@ -5,6 +5,7 @@
     --darkgreen: #b1b9ac;
     --darkergreen: #4b5346;
     --lightgray: lightgray;
+    --gray: gainsboro;
     --darkgray: darkgray;
 
     /* style */
@@ -136,6 +137,10 @@ blockquote {
     background-color: var(--lightgray);
     font-size: 90%;
     width: 80%;
+}
+
+blockquote code {
+    background-color: var(--gray);
 }
 
 sup {


### PR DESCRIPTION
This way, code actually pops out a bit more when within blockquotes
