### PR TITLE
fix(yarn): Fix a misspelling and minor punctuation

### DIFF
--- a/tech/2023-11-07-yarn.md
+++ b/tech/2023-11-07-yarn.md
@@ -100,17 +100,17 @@ the step of syncing the host's working tree into the container volume was adding
 to container creation time and multiple seconds to a lot of common operations. In
 general, it was a significant developer productivity hindrance.
 
-However, removing that volume and therefore the sync step by using a bind-mount instead
+However, removing that volume and therefore the sync step by using a bind mount instead
 was not serving developers any better. While container creation and common operations
 were now "syncless" and therefore gained a bunch of time savings, that time savings was
 completely eaten up by significantly slower build times.
 
-File I/O across the bind-mount simply couldn't keep up with the build process, as
+File I/O across the bind mount simply couldn't keep up with the build process, as
 multiple files were constantly being created/referenced/etc. within the host's
 node_modules directory. If only there were a way to drastically reduce the amount of
 file I/O required during the build... what if the entire node_modules directory was
 replaced with a single file called something like, say, `.pnp.cjs`? Then, we might be
-able to use a bind-mount and benefit from the performance gains from syncless _and_ have
+able to use a bind mount and benefit from the performance gains from syncless _and_ have
 speedy builds not bottlenecked by file I/O!
 
 It was clear that PnP showed a lot of promise in our current setup. The potential
@@ -189,7 +189,7 @@ migration:
 >   - removing them from `pnpIgnorePatterns` in the central `.yarnrc.yml`
 >   - getting it building with `pnp`
 >
-> Once thing that I'm not sure about is how opted-in and opted-out packages would
+> One thing that I'm not sure about is how opted-in and opted-out packages would
 > interact with one another. Past self makes it sound like I investigated this and
 > determined that linking PnP-based packages to node-modules-based packages wasn't
 > supported, but now I don't remember if/why this is the case. That would be something
@@ -247,7 +247,7 @@ functionality, which is a faster file I/O implementation. It has since become th
 default implementation in [newer versions](
 https://docs.docker.com/desktop/release-notes/#4210).
 
-Also, now that we could efficiently use a bind-mount, we could remove the sync step to
+Also, now that we could efficiently use a bind mount, we could remove the sync step to
 get the host's working tree into the container's volume, and the volume itself. Now, our
 containers could be configured to be syncless! So not only did we get huge build
 performance gains out of this effort, but we also shaved multiple minutes off of
@@ -295,3 +295,9 @@ resulted in a less painful process? I'm curious to hear about other experiences!
 [^0]: [https://yarnpkg.com/features/pnp#how-does-it-work](https://yarnpkg.com/features/pnp#how-does-it-work)
 [^1]: [The history of pets vs cattle](http://cloudscaling.com/blog/cloud-computing/the-history-of-pets-vs-cattle/)
 [^2]: By the end of this effort, my MacBook CPU was legitimately cooked. Things started breaking in very weird ways, and diagnostics at the Genius Bar reported back that it had seen sustained high temperature events very frequently. 8 hours of compilation a day can do that I guess.
+
+---
+
+**Article edits**
+
+- **2023-11-08**: A misspelling and some punctuation fixes


### PR DESCRIPTION
- s/Once/One
- Standardize on "bind mount", not "bind-mount"
